### PR TITLE
Add uefistored dependencies, fix some of Travis CI's complaints

### DIFF
--- a/run.py
+++ b/run.py
@@ -45,7 +45,8 @@ def main():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--branch',
-                        help='XCP-ng version: 7.6, %s, etc. If not set, will default to %s.' % (DEFAULT_BRANCH, DEFAULT_BRANCH))
+                        help=('XCP-ng version: 7.6, %s, etc. If not set, will default to '
+                              '%s.') % (DEFAULT_BRANCH, DEFAULT_BRANCH))
     parser.add_argument('-l', '--build-local',
                         help="Install dependencies for the spec file(s) found in the SPECS/ subdirectory "
                              "of the directory passed as parameter, then build the RPM(s). "

--- a/run.py
+++ b/run.py
@@ -157,7 +157,7 @@ def main():
 
     # exec "docker run"
     docker_args += ["%s:%s" % (CONTAINER_PREFIX, branch), "/usr/local/bin/init-container.sh"]
-    print >> sys.stderr, "Launching docker with args %s" % docker_args
+    print("Launching docker with args %s" % docker_args, file=sys.stderr)
     return_code = subprocess.call(docker_args)
 
     if srpm_mount_dir:

--- a/run.py
+++ b/run.py
@@ -141,7 +141,7 @@ def main():
     if args.dir:
         for localdir in args.dir:
             if not os.path.isdir(localdir):
-                print "Local directory argument is not a directory!"
+                print("Local directory argument is not a directory!")
                 sys.exit(1)
             ext_path = os.path.abspath(localdir)
             int_path = os.path.basename(ext_path)
@@ -161,7 +161,7 @@ def main():
     return_code = subprocess.call(docker_args)
 
     if srpm_mount_dir:
-        print "Cleaning up temporary mount directory"
+        print("Cleaning up temporary mount directory")
         shutil.rmtree(srpm_mount_dir)
 
     sys.exit(return_code)

--- a/run.py
+++ b/run.py
@@ -15,7 +15,7 @@ import uuid
 CONTAINER_PREFIX = "xcp-ng/xcp-ng-build-env"
 SRPMS_MOUNT_ROOT = "/tmp/docker-SRPMS"
 
-DEFAULT_BRANCH='8.0'
+DEFAULT_BRANCH = '8.0'
 
 def make_mount_dir():
     """

--- a/run.py
+++ b/run.py
@@ -17,6 +17,7 @@ SRPMS_MOUNT_ROOT = "/tmp/docker-SRPMS"
 
 DEFAULT_BRANCH = '8.0'
 
+
 def make_mount_dir():
     """
     Make a randomly-named directory under SRPMS_MOUNT_ROOT.

--- a/test/travis-test.sh
+++ b/test/travis-test.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-./build.sh dev
+./build.sh 8.2
 
 PACKAGE=emu-manager
 REPO=xcp-emu-manager


### PR DESCRIPTION
This PR adds all of the things necessary to build the `uefistored` RPM as it is written in [the PR for v0.4.0](https://github.com/xcp-ng-rpms/uefistored/pull/2)

Also fixes a few of pep8/pylint things.