### PR TITLE
Automagic sync of UID/GID with the ones of the current host's user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
+os: linux
+dist: bionic
 language: python
-sudo: required
+python:
+  - "2.7"
 services:
   - docker
 install:
-  - pip install pep8
+  - pip install pycodestyle
   - pip install pylint
 script:
-  - pep8 --max-line-length=120 --show-source --show-pep8 run.py
+  - pycodestyle --max-line-length=120 --show-source --show-pep8 run.py
   - pylint run.py
   - ./test/travis-test.sh

--- a/Dockerfile-7.x
+++ b/Dockerfile-7.x
@@ -1,5 +1,8 @@
 FROM    centos:7.2.1511
 
+ARG     CUSTOM_BUILDER_UID=""
+ARG     CUSTOM_BUILDER_GID=""
+
 # Remove all repositories
 RUN     rm /etc/yum.repos.d/*
 
@@ -44,7 +47,19 @@ RUN     yum install -y \
 RUN     sed -i "/gpgkey/a exclude=ocaml*" /etc/yum.repos.d/Cent* /etc/yum.repos.d/epel*
 
 # Set up the builder user
-RUN     useradd builder \
+RUN     bash -c ' \
+            if [ -n "${CUSTOM_BUILDER_UID}" ]; then \
+                if [ -z "${CUSTOM_BUILDER_GID}" ]; then \
+                    export CUSTOM_BUILDER_GID="${CUSTOM_BUILDER_UID}"; \
+                fi; \
+                if ! egrep -q "^.*:.:${CUSTOM_BUILDER_GID}:"; then \
+                    groupadd -g "${CUSTOM_BUILDER_GID}" builder; \
+                fi; \
+                useradd -u "${CUSTOM_BUILDER_UID}" -g "${CUSTOM_BUILDER_GID}" builder; \
+            else \
+                useradd builder; \
+            fi; \
+        ' \
         && echo "builder:builder" | chpasswd \
         && echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers \
         && usermod -G mock builder

--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ git clone https://github.com/xcp-ng-rpms/xapi.git
 /path/to/run.py -b 8.0 --build-local xapi/ --rm
 ```
 
-**Warning:** The --build-local switch assumes that your current user has uid 1000. If it's not the case, it will fail at writing to the directory passed as parameter (xapi/ in our example). You can workaround that by changing the owner of the directory and everything it contains. Example: `sudo chown 1000.1000 xapi/ -R`.
-
 **Important switches**
 
 * `-b` / `--branch` allows to select which version of XCP-ng to work on (defaults to the latest known version if not specified).
@@ -160,7 +158,7 @@ example, if I clone some repos into a directory on my host, say `/work/code/`,
 then I can mount it inside the container as follows:
 
 ```sh
-docker run -i -t -v /work/code:/mnt/repos -u $(id -u) <IMAGE> /bin/bash
+docker run -i -t -v /work/code:/mnt/repos -u builder <IMAGE> /bin/bash
 ```
 
 The `-u` flag uses the right UID inside so that changes made in the container

--- a/build.sh
+++ b/build.sh
@@ -8,9 +8,18 @@ fi
 
 CUSTOM_ARGS=()
 
+DEFAULT_VERSION="8.2"
 MAJOR=${1:0:1}
 
-if [ $MAJOR -eq 7 ]; then
+RE_ISNUM='^[0-9]$'
+if ! [[ ${MAJOR} =~ ${RE_ISNUM} ]]; then
+    echo "[WARNING] The first character of version should be a number: '${MAJOR}' was passed:"
+    MAJOR=8
+    set -- "${DEFAULT_VERSION}" "${@:2}"
+    echo "          using default version ${1}"
+fi
+
+if [ ${MAJOR} -eq 7 ]; then
     REPO_FILE=files/xcp-ng.repo.7.x.in
     CENTOS_VERSION=7.2.1511
 else
@@ -18,8 +27,8 @@ else
     CENTOS_VERSION=7.5.1804
 fi
 
-sed -e "s/@XCP_NG_BRANCH@/$1/g" "$REPO_FILE" > files/tmp-xcp-ng.repo
-sed -e "s/@CENTOS_VERSION@/$CENTOS_VERSION/g" files/CentOS-Vault.repo.in > files/tmp-CentOS-Vault.repo
+sed -e "s/@XCP_NG_BRANCH@/${1}/g" "$REPO_FILE" > files/tmp-xcp-ng.repo
+sed -e "s/@CENTOS_VERSION@/${CENTOS_VERSION}/g" files/CentOS-Vault.repo.in > files/tmp-CentOS-Vault.repo
 
 # Support using docker on arm64, building
 # for amd64 (e.g. Apple Silicon)
@@ -34,8 +43,8 @@ CUSTOM_ARGS+=( "--build-arg" "CUSTOM_BUILDER_GID=$(id -g)" )
 
 docker build \
     $(echo "${CUSTOM_ARGS[@]}") \
-    -t xcp-ng/xcp-ng-build-env:$1 \
-    -f Dockerfile-$MAJOR.x .
+    -t xcp-ng/xcp-ng-build-env:${1} \
+    -f Dockerfile-${MAJOR}.x .
 
 rm -f files/tmp-xcp-ng.repo
 rm -f files/tmp-CentOS-Vault.repo

--- a/build.sh
+++ b/build.sh
@@ -21,5 +21,5 @@ sed -e "s/@CENTOS_VERSION@/$CENTOS_VERSION/g" files/CentOS-Vault.repo.in > files
 
 docker build -t xcp-ng/xcp-ng-build-env:$1 -f Dockerfile-$MAJOR.x .
 
-rm files/tmp-xcp-ng.repo -f
-rm files/tmp-CentOS-Vault.repo -f
+rm -f files/tmp-xcp-ng.repo
+rm -f files/tmp-CentOS-Vault.repo

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,11 @@ fi
 sed -e "s/@XCP_NG_BRANCH@/$1/g" "$REPO_FILE" > files/tmp-xcp-ng.repo
 sed -e "s/@CENTOS_VERSION@/$CENTOS_VERSION/g" files/CentOS-Vault.repo.in > files/tmp-CentOS-Vault.repo
 
+# Support using docker on arm64, building
+# for amd64 (e.g. Apple Silicon)
+if [ "$(uname -m)" == "arm64" ]; then
+    CUSTOM_ARGS+=( "--platform" "linux/amd64" )
+fi
 
 # Support for seamless use of current host user
 # and Docker user "builder" inside the image

--- a/run.py
+++ b/run.py
@@ -45,7 +45,8 @@ def main():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--branch',
-                        help='XCP-ng version: 7.6, %s, etc. If not set, will default to %s.' % (DEFAULT_BRANCH, DEFAULT_BRANCH))
+                        help='XCP-ng version: 7.6, %s, etc. If not set, '
+                             'will default to %s.' % (DEFAULT_BRANCH, DEFAULT_BRANCH))
     parser.add_argument('-l', '--build-local',
                         help="Install dependencies for the spec file(s) found in the SPECS/ subdirectory "
                              "of the directory passed as parameter, then build the RPM(s). "

--- a/run.py
+++ b/run.py
@@ -15,7 +15,8 @@ import uuid
 CONTAINER_PREFIX = "xcp-ng/xcp-ng-build-env"
 SRPMS_MOUNT_ROOT = "/tmp/docker-SRPMS"
 
-DEFAULT_BRANCH='8.0'
+DEFAULT_BRANCH = '8.0'
+
 
 def make_mount_dir():
     """
@@ -93,6 +94,7 @@ def main():
                         help='Command to run inside the prepared container')
 
     args = parser.parse_args(sys.argv[1:])
+
     docker_args = ["docker", "run", "-i", "-t", "-u", "builder"]
     if os.uname()[4] == "arm64":
         docker_args += ["--platform", "linux/amd64"]
@@ -103,7 +105,8 @@ def main():
     if args.command != []:
         docker_args += ["-e", "COMMAND=%s" % ' '.join(args.command)]
     if args.build_local:
-        docker_args += ["-v", "%s:/home/builder/rpmbuild" % os.path.abspath(args.build_local)]
+        docker_args += ["-v", "%s:/home/builder/rpmbuild" %
+                        os.path.abspath(args.build_local)]
         docker_args += ["-e", "BUILD_LOCAL=1"]
     if args.define:
         docker_args += ["-e", "RPMBUILD_DEFINE=%s" % args.define]
@@ -111,15 +114,19 @@ def main():
         if not os.path.isfile(args.rebuild_srpm) or not args.rebuild_srpm.endswith(".src.rpm"):
             parser.error("%s is not a valid source RPM." % args.rebuild_srpm)
         if not args.output_dir:
-            parser.error("Missing --output-dir parameter, required by --rebuild-srpm.")
-        docker_args += ["-e", "REBUILD_SRPM=%s" % os.path.basename(args.rebuild_srpm)]
+            parser.error(
+                "Missing --output-dir parameter, required by --rebuild-srpm.")
+        docker_args += ["-e", "REBUILD_SRPM=%s" %
+                        os.path.basename(args.rebuild_srpm)]
         if args.srpm is None:
             args.srpm = []
         args.srpm.append(args.rebuild_srpm)
     if args.output_dir:
         if not os.path.isdir(args.output_dir):
-            parser.error("%s is not a valid output directory." % args.output_dir)
-        docker_args += ["-v", "%s:/home/builder/output" % os.path.abspath(args.output_dir)]
+            parser.error("%s is not a valid output directory." %
+                         args.output_dir)
+        docker_args += ["-v", "%s:/home/builder/output" %
+                        os.path.abspath(args.output_dir)]
     if args.no_exit:
         docker_args += ["-e", "NO_EXIT=1"]
     if args.fail_on_error:
@@ -156,7 +163,8 @@ def main():
         docker_args += ["-e", "ENABLEREPO=%s" % args.enablerepo]
 
     # exec "docker run"
-    docker_args += ["%s:%s" % (CONTAINER_PREFIX, branch), "/usr/local/bin/init-container.sh"]
+    docker_args += ["%s:%s" % (CONTAINER_PREFIX, branch),
+                    "/usr/local/bin/init-container.sh"]
     print >> sys.stderr, "Launching docker with args %s" % docker_args
     return_code = subprocess.call(docker_args)
 

--- a/run.py
+++ b/run.py
@@ -94,6 +94,8 @@ def main():
 
     args = parser.parse_args(sys.argv[1:])
     docker_args = ["docker", "run", "-i", "-t", "-u", "builder"]
+    if os.uname()[4] == "arm64":
+        docker_args += ["--platform", "linux/amd64"]
     if args.rm:
         docker_args += ["--rm=true"]
     branch = args.branch or DEFAULT_BRANCH

--- a/test/travis-test.sh
+++ b/test/travis-test.sh
@@ -2,7 +2,9 @@
 
 set -eux
 
-./build.sh dev
+TARGET_XCP_NG_VERSION="8.2"
+
+./build.sh "${TARGET_XCP_NG_VERSION}"
 
 PACKAGE=emu-manager
 REPO=xcp-emu-manager
@@ -20,5 +22,6 @@ cd /tmp/$REPO
 REPO_PACKAGE_NAME=$PACKAGE \
     REPO_CONFIGURE_CMD=true \
     REPO_BUILD_CMD=make \
-    REPO_TEST_CMD=true\
+    REPO_TEST_CMD=true \
+    TARGET_XCP_NG_VERSION="${TARGET_XCP_NG_VERSION}" \
     bash travis-build-repo.sh

--- a/utils/travis-build-repo.sh
+++ b/utils/travis-build-repo.sh
@@ -49,6 +49,7 @@ REPO_DOC_CMD=${REPO_DOC_CMD-}
 
 python run.py -p $REPO_PACKAGE_NAME --name ${CONTAINER_NAME} \
     --fail-on-error \
+    -b "${TARGET_XCP_NG_VERSION}" \
     -e "REPO_CONFIGURE_CMD=$REPO_CONFIGURE_CMD" \
     -e "REPO_BUILD_CMD=$REPO_BUILD_CMD" \
     -e "REPO_TEST_CMD=$REPO_TEST_CMD" \


### PR DESCRIPTION
The following PR addresses a few things, although all commits part of it are _"atomic"_, therefore they can be somehow cherry-picked is any of them should result as non-desirable:

- (3a7a570) Fix for a typo/bug in the `rm` command at the end of `build.sh` where the `-f` option is at the end instead of being passed in as first argument _(as it was bash thinks `-f` is the name of a file to remove instead of being and option)_
- (0ebcb24) Adaptation of both `Dockerfile`s to receive 2 optional arguments providing custom User ID and Group ID to be used during the creation of the `builder` user _(also handles smoothly cases where the group already exist or just the User ID is passed in)_
- (942d319) Changes to smoothly allow cross building on systems with arm64 architecture _(eventually running Docker over QEMU)_. This is the case, for instance of new Apple Silicon machines.
- (f7315cd) Reformat of `run.py` to be PEP8 compliant
- (65674f1) Update the `README.md` file to remove the working about the use of `--build-local` with users than have different UID/GID than `1000/1000` _(thanks to the previous changes part of this PR now everything is seamless)_
- (65674f1) Also update in `README.md` to suggest using the `builder` user for develoment as there is _(once again)_ no more need to pass in any further configuration _(as the container image has been built with the current user's IDs already baked-in)_

The documentation does not include nor mention the changes to the `Dockerfile`s, nor the possibility to manually build them without `build.sh` and still obtain the same result passing-in the right arguments _(this information can be added if desirable)_.

Thanks 🙏