### PR TITLE
Fix `build.sh` to be usable outside its dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,8 @@ if [ -z "$1" ]; then
     exit
 fi
 
+cd $(dirname "$0")
+
 CUSTOM_ARGS=()
 
 DEFAULT_VERSION="8.2"


### PR DESCRIPTION
Until now it'd only work with `./build.sh`.
Now it can be called from anywhere and the current dir of the script is modified.

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>