### PR TITLE
Add support for --ulimit command line option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,7 @@ CUSTOM_ARGS+=( "--build-arg" "CUSTOM_BUILDER_GID=${CUSTOM_GID}" )
 docker build \
     $(echo "${CUSTOM_ARGS[@]}") \
     -t xcp-ng/xcp-ng-build-env:${1} \
+    --ulimit nofile=1024 \
     -f Dockerfile-${MAJOR}.x .
 
 rm -f files/tmp-xcp-ng.repo


### PR DESCRIPTION
This change adds support for --ulimit option to be passed directly to 'docker run'.

This is useful on Fedora running the build-env container as using 'yum install' from inside the container may be very slow because the maximum number of file descriptors reported by 'ulimit -n' is set to a crazy high value. Passing '--ulimit nofile=1024' to run.py solves this issue. This has been observed on Fedora, running CentOS 7.5 docker image, and might be related to bug [1] which has been fixed in rpm v1.14.2.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1537564