### PR TITLE
Force keep ncurses5 in base container

### DIFF
--- a/Dockerfile-8.x
+++ b/Dockerfile-8.x
@@ -24,10 +24,17 @@ RUN     yum install -y yum-plugin-ovl
 RUN     yum install -y yum-plugin-priorities
 
 # Update
-RUN     yum update -y
+RUN     yum update -y \
+            --exclude ncurses-base \
+            --exclude ncurses-libs \
+            --exclude ncurses
 
 # Common build requirements
 RUN     yum install -y \
+            --exclude ncurses-base \
+            --exclude ncurses-libs \
+            --exclude ncurses \
+            openssh-clients-7.4p1-23.2.1.xcpng8.3 \
             gcc \
             gcc-c++ \
             git \

--- a/files/init-container.sh
+++ b/files/init-container.sh
@@ -18,7 +18,12 @@ if [ -n "$ENABLEREPO" ]; then
 fi
 
 # update to either install newer updates or to take packages from added repos into account
-sudo yum update -y --disablerepo=epel
+sudo yum update -y --disablerepo=epel \
+                --exclude ncurses-base \
+                --exclude ncurses-libs \
+                --exclude ncurses \
+                --exclude openssh-clients \
+                --exclude openssh
 
 cd "$HOME"
 


### PR DESCRIPTION
From XenServer 8.4 we inherit ncurses6, but linking against this one could trigger issues if a variable must be used by both with different types (ncurses project provides no such explicit information to help detect such issues, though we might dig into ncurses-compat to find out).

To be on the safe side, since any package rebuild must be able to link against ncurses5, we have to prevent upgrade to ncurses6 until we know we want it (since downgrading would be unnecessarily difficult), and we have to pin openssh to an older version, since we did rebuild it against ncurses6 aleady.