### PR TITLE
Disable upstream repositories by default

### DIFF
--- a/container/Dockerfile-8.x
+++ b/container/Dockerfile-8.x
@@ -10,6 +10,8 @@ ARG     CENTOS_VERSION
 COPY    files/CentOS-Vault.repo.in /etc/yum.repos.d/CentOS-Vault-7.5.repo
 RUN     sed -i -e "s/@CENTOS_VERSION@/${CENTOS_VERSION}/g" /etc/yum.repos.d/CentOS-Vault-7.5.repo
 
+ENV     UPSTREAM_REPOS="C${CENTOS_VERSION}-base C${CENTOS_VERSION}-updates C${CENTOS_VERSION}-extras"
+
 # Add our repositories
 # Repository file depends on the target version of XCP-ng, and is pre-processed by build.sh
 ARG     XCP_NG_BRANCH=8.3

--- a/container/files/CentOS-Vault.repo.in
+++ b/container/files/CentOS-Vault.repo.in
@@ -4,7 +4,7 @@ baseurl=http://vault.centos.org/@CENTOS_VERSION@/os/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 exclude=ocaml*
-enabled=1
+enabled=0
 
 [C@CENTOS_VERSION@-updates]
 name=CentOS-@CENTOS_VERSION@ - Updates
@@ -12,7 +12,7 @@ baseurl=http://vault.centos.org/@CENTOS_VERSION@/updates/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 exclude=ocaml*
-enabled=1
+enabled=0
 
 [C@CENTOS_VERSION@-extras]
 name=CentOS-@CENTOS_VERSION@ - Extras
@@ -20,7 +20,7 @@ baseurl=http://vault.centos.org/@CENTOS_VERSION@/extras/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 exclude=ocaml*
-enabled=1
+enabled=0
 
 [C@CENTOS_VERSION@-base-source]
 name=CentOS-@CENTOS_VERSION@ - Base

--- a/container/files/init-container.sh
+++ b/container/files/init-container.sh
@@ -46,6 +46,13 @@ case "$OS_RELEASE" in
     *) echo >&2 "ERROR: unknown release, cannot know package manager"; exit 1 ;;
 esac
 
+# enable upstream repositories if needed
+if [ "$ENABLE_UPSTREAM_REPOS" == "true" ]; then
+    for repo in "$UPSTREAM_REPOS"; do
+        sudo $CFGMGR --enable "$repo"
+    done
+fi
+
 # disable repositories if needed
 if [ -n "$DISABLEREPO" ]; then
     sudo $CFGMGR --disable "$DISABLEREPO"

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -92,6 +92,7 @@ def add_common_args(parser):
     group.add_argument('--disablerepo',
                        help='disable repositories. Same syntax as yum\'s --disablerepo parameter. '
                        'If both --enablerepo and --disablerepo are set, --disablerepo will be applied first')
+    group.add_argument('-U', '--enable-upstream-repos', action='store_true', help='enable the upstream repositories')
     group.add_argument('--no-update', action='store_true',
                        help='do not run "yum update" on container start, use it as it was at build time')
     group.add_argument('--no-network', action='store_true',
@@ -263,6 +264,8 @@ def container(args):
     if args.env:
         for env in args.env:
             docker_args += ["-e", env]
+    if args.enable_upstream_repos:
+        docker_args += ["-e", "ENABLE_UPSTREAM_REPOS=true"]
     if args.enablerepo:
         docker_args += ["-e", "ENABLEREPO=%s" % args.enablerepo]
     if args.disablerepo:


### PR DESCRIPTION
and add the --enable-upstream-repos option (-U for short) to enable them.

This allows to generate an error when a dependency is not aleardy packaged in XCP-ng. The developer can then decide if the dependency should be either imported or removed.

We may also want to disable all the repositories for the not-yet-published XCP-ng packages (`xcp-ng-candidates`, `xcp-ng-ci` and `xcp-ng-testing`).