### PR TITLE
Add a --no-update flag to disable the "yum update" call

### DIFF
--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -56,6 +56,8 @@ def add_common_args(parser):
     parser.add_argument('--disablerepo',
                         help='disable repositories. Same syntax as yum\'s --disablerepo parameter. '
                              'If both --enablerepo and --disablerepo are set, --disablerepo will be applied first')
+    parser.add_argument('--no-update', action='store_true',
+                        help='do not run "yum update" on container start, use it as it was at build time')
 
 def add_container_args(parser):
     parser.add_argument('-v', '--volume', action='append',
@@ -204,6 +206,9 @@ def container(args):
         docker_args += ["-e", "ENABLEREPO=%s" % args.enablerepo]
     if args.disablerepo:
         docker_args += ["-e", "DISABLEREPO=%s" % args.disablerepo]
+    if args.no_update:
+        docker_args += ["-e", "NOUPDATE=1"]
+
     ulimit_nofile = False
     if args.ulimit:
         for ulimit in args.ulimit:

--- a/src/xcp_ng_dev/files/init-container.sh
+++ b/src/xcp_ng_dev/files/init-container.sh
@@ -54,8 +54,10 @@ if [ -n "$ENABLEREPO" ]; then
     sudo $CFGMGR --enable "$ENABLEREPO"
 fi
 
-# update to either install newer updates or to take packages from added repos into account
-sudo $DNF update -y --disablerepo=epel
+if [ -z "$NOUPDATE" ]; then
+    # update to either install newer updates or to take packages from added repos into account
+    sudo $DNF update -y --disablerepo=epel
+fi
 
 cd "$HOME"
 


### PR DESCRIPTION
This is useful for:
- avoiding network transfers when just a build is required (though this is only preliminary, and needs some support to use cached breqs)
- people working through their phone connection and willing to spare some data transfer (and yes, cached breqs will be a boon there too)