### PR TITLE
Always stop on error

### DIFF
--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -73,9 +73,6 @@ def add_container_args(parser):
     group.add_argument('--platform', action='store',
                        help="Override the default platform for the build container. "
                        "Can notably be used to workaround podman bug #6185 fixed in v5.5.1.")
-    group.add_argument('--fail-on-error', action='store_true',
-                       help='If container initialisation fails, exit rather than dropping the user '
-                       'into a shell')
     group.add_argument('--debug', action='store_true',
                        help='Enable script tracing in container initialization (sh -x)')
 
@@ -199,8 +196,6 @@ def container(args):
                                     else "linux/amd64")
     docker_args += ["--platform", docker_arch]
 
-    if args.fail_on_error:
-        docker_args += ["-e", "FAIL_ON_ERROR=1"]
     if args.debug:
         docker_args += ["-e", "SCRIPT_DEBUG=1"]
 

--- a/src/xcp_ng_dev/files/init-container.sh
+++ b/src/xcp_ng_dev/files/init-container.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
+set -e
 
-if [ -n "$FAIL_ON_ERROR" ]; then
-    set -e
-fi
 if [ -n "$SCRIPT_DEBUG" ]; then
     set -x
 fi

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,6 +16,5 @@ for REPO in ${REPOS}; do
     git clone --branch "$TARGET_XCP_NG_VERSION" https://github.com/xcp-ng-rpms/"$REPO" "$REPO_PATH"
 
     xcp-ng-dev container build "$TARGET_XCP_NG_VERSION" "$REPO_PATH" \
-        --name "$CONTAINER_NAME" \
-        --fail-on-error
+        --name "$CONTAINER_NAME"
 done


### PR DESCRIPTION
We previously could not use `set -e` systematically, because that would break `--no-exit`.  This reimplements the latter so we can a last have the former, and drops no useless/default `--fail-on-error`.