### PR TITLE
Bootstrap container

### DIFF
--- a/container/files/init-container.sh
+++ b/container/files/init-container.sh
@@ -9,6 +9,14 @@ if [ -n "$NO_EXIT" ]; then
     trap "/bin/bash --login" EXIT
 fi
 
+os_name()
+{
+    (
+        source /etc/os-release
+        echo "$NAME"
+    )
+}
+
 os_release()
 {
     (
@@ -17,12 +25,13 @@ os_release()
     )
 }
 
+OS_NAME=$(os_name)
 OS_RELEASE=$(os_release)
 
 # get list of user repos
-case "$OS_RELEASE" in
-    8.2.*) XCPREL=8/8.2 ;;
-    8.3.*) XCPREL=8/8.3 ;;
+case "$OS_NAME,$OS_RELEASE" in
+    XCP-ng,8.2.*) XCPREL=8/8.2 ;;
+    XCP-ng,8.3.*) XCPREL=8/8.3 ;;
     *) echo >&2 "WARNING: unknown release, not fetching user repo definitions" ;;
 esac
 
@@ -32,13 +41,13 @@ if [ -n "$XCPREL" ]; then
 fi
 
 # yum or dnf?
-case "$OS_RELEASE" in
-    8.2.*|8.3.*)
+case "$OS_NAME,$OS_RELEASE" in
+    XCP-ng,8.2.*|XCP-ng,8.3.*)
         DNF=yum
         CFGMGR=yum-config-manager
         BDEP=yum-builddep
         ;;
-    8.99.*|9.*|10.*) # FIXME 10.* actually to bootstrap Alma10
+    XCP-ng,8.99.*|XCP-ng,9.*|AlmaLinux,10.*)
         DNF=dnf
         CFGMGR="dnf config-manager"
         BDEP="dnf builddep"
@@ -86,9 +95,9 @@ if [ -n "$BUILD_LOCAL" ]; then
         fi
         echo "Found specfiles $specs"
 
-        case "$OS_RELEASE" in
-            8.2.*|8.3.*) ;; # sources always available via git-lfs
-            8.99.*|9.*) if [ -r sources ]; then alma_get_sources -i sources; fi ;;
+        case "$OS_NAME,$OS_RELEASE" in
+            XCP-ng,8.2.*|XCP-ng,8.3.*) ;; # sources always available via git-lfs
+            XCP-ng,8.99.*|XCP-ng,9.*) if [ -r sources ]; then alma_get_sources -i sources; fi ;;
             *) echo >&2 "ERROR: unknown release, cannot know package manager"; exit 1 ;;
         esac
 

--- a/container/files/init-container.sh
+++ b/container/files/init-container.sh
@@ -97,8 +97,8 @@ if [ -n "$BUILD_LOCAL" ]; then
 
         case "$OS_NAME,$OS_RELEASE" in
             XCP-ng,8.2.*|XCP-ng,8.3.*) ;; # sources always available via git-lfs
-            XCP-ng,8.99.*|XCP-ng,9.*) if [ -r sources ]; then alma_get_sources -i sources; fi ;;
-            *) echo >&2 "ERROR: unknown release, cannot know package manager"; exit 1 ;;
+            XCP-ng,8.99.*|XCP-ng,9.*|AlmaLinux,10.*) if [ -r sources ]; then alma_get_sources -i sources; fi ;;
+            *) echo >&2 "ERROR: unknown release, don't know how to find sources"; exit 1 ;;
         esac
 
         sudo $BDEP "${SPECFLAGS[@]}" -y $specs

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -55,6 +55,10 @@ def add_common_args(parser):
                        'If both --enablerepo and --disablerepo are set, --disablerepo will be applied first')
     group.add_argument('--no-update', action='store_true',
                        help='do not run "yum update" on container start, use it as it was at build time')
+    group.add_argument('--bootstrap', action='store_true',
+                       help='use a bootstrap build-env, able to build xc-ng-release')
+    group.add_argument('--isarpm', action='store_true',
+                       help='(internal) use a build-env suitable for the ISARPM build system')
     group.add_argument('--no-network', action='store_true',
                        help='disable all networking support in the build environment')
 
@@ -248,8 +252,14 @@ def container(args):
     if wants_interactive:
         docker_args += ["--interactive", "--tty"]
 
+    tag = args.container_version
+    if args.bootstrap:
+        tag += "-bootstrap"
+    if args.isarpm:
+        tag += "-isarpm"
+
     # exec "docker run"
-    docker_args += [f"{CONTAINER_PREFIX}:{args.container_version}",
+    docker_args += [f"{CONTAINER_PREFIX}:{tag}",
                     "/usr/local/bin/init-container.sh"]
     print("Launching docker with args %s" % docker_args, file=sys.stderr)
     return subprocess.call(docker_args)


### PR DESCRIPTION
This adds support for building all packages from scratch, most notably `xcp-ng-release` and its `branding` breq, which are required to build any (other) package.

This only targets v9 for now.