### PR TITLE
New --ccache option to cache build artifacts

### DIFF
--- a/container/Dockerfile-9.x
+++ b/container/Dockerfile-9.x
@@ -34,6 +34,7 @@ RUN     dnf update -y \
         && dnf install -y \
             epel-rpm-macros \
             almalinux-git-utils \
+            ccache \
         # Niceties
         && dnf install -y \
             bash-completion \

--- a/container/files/init-container.sh
+++ b/container/files/init-container.sh
@@ -17,6 +17,10 @@ os_release()
     )
 }
 
+if [ -n "${PATH_PREPEND}" ]; then
+    PATH="${PATH_PREPEND}:${PATH}"
+fi
+
 OS_RELEASE=$(os_release)
 
 # get list of user repos

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -46,6 +46,8 @@ def add_common_args(parser):
     group.add_argument('-e', '--env', action='append',
                        help='Environment variables passed directly to '
                        f'{RUNNER} -e')
+    parser.add_argument('--ccache', action='store',
+                        help="Use given directory as a cache for ccache")
     group.add_argument('-a', '--enablerepo',
                        help='additional repositories to enable before installing build dependencies. '
                        'Same syntax as yum\'s --enablerepo parameter. Available additional repositories: '
@@ -171,6 +173,12 @@ def container(args):
     if args.env:
         for env in args.env:
             docker_args += ["-e", env]
+    if args.ccache:
+        os.makedirs(args.ccache, exist_ok=True)
+        docker_args += ["-v", f"{os.path.realpath(args.ccache)}:/home/builder/ccachedir",
+                        "-e", "CCACHE_DIR=/home/builder/ccachedir",
+                        "-e", "PATH_PREPEND=/usr/lib64/ccache",
+                        ]
     if args.enablerepo:
         docker_args += ["-e", "ENABLEREPO=%s" % args.enablerepo]
     if args.disablerepo:


### PR DESCRIPTION
Quite necessary for upcoming rebuilds of the kernel package.

Includes a new PATH_PREPEND interface to the container.