### PR TITLE
build.sh: disable security label for podman, like we do at "run" time

### DIFF
--- a/container/build.sh
+++ b/container/build.sh
@@ -110,6 +110,10 @@ case "$PLATFORM" in
         ;;
 esac
 
+if [ "$RUNNER" = "podman" ]; then
+    EXTRA_ARGS+=("--security-opt" "label=disable")
+fi
+
 "$RUNNER" build \
     --platform "$PLATFORM" \
     -t ghcr.io/xcp-ng/xcp-ng-build-env:${1} \


### PR DESCRIPTION
This is necessary to create the container on machines with SELinux enabled, which is the default for some distros like AlmaLinux 10.