### PR TITLE
cli: check for directory arguments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @xcp-ng/os-platform-release

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -36,11 +36,18 @@ def is_podman(runner):
         return True
     return subprocess.getoutput(f"{runner} --version").startswith("podman ")
 
+def dir_path(path):
+    """Argument type for argparse"""
+    if os.path.isdir(path):
+        return path
+    else:
+        raise argparse.ArgumentTypeError(f"{path} is not a valid directory path")
+
 def add_common_args(parser):
     group = parser.add_argument_group("common arguments")
     group.add_argument('-n', '--no-exit', action='store_true',
                        help='After finishing the execution of the action, drop user into a shell')
-    group.add_argument('-d', '--dir', action='append',
+    group.add_argument('-d', '--dir', action='append', type=dir_path,
                        help='Local dir to mount in the '
                        'image. Will be mounted at /external/<dirname>')
     group.add_argument('-e', '--env', action='append',
@@ -102,7 +109,7 @@ def buildparser():
     add_container_args(parser_build)
     group_build = parser_build.add_argument_group("build arguments")
     group_build.add_argument(
-        'source_dir', nargs='?', default='.',
+        'source_dir', nargs='?', type=dir_path, default='.',
         help="Root path where SPECS/ and SOURCES are available. "
              "The default is the working directory")
     group_build.add_argument(

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -78,11 +78,18 @@ def get_local_image_platform(runner, image):
         pass
     return None
 
+def dir_path(path):
+    """Argument type for argparse"""
+    if os.path.isdir(path):
+        return path
+    else:
+        raise argparse.ArgumentTypeError(f"{path} is not a valid directory path")
+
 def add_common_args(parser):
     group = parser.add_argument_group("common arguments")
     group.add_argument('-n', '--no-exit', action='store_true',
                        help='After finishing the execution of the action, drop user into a shell')
-    group.add_argument('-d', '--dir', action='append',
+    group.add_argument('-d', '--dir', action='append', type=dir_path,
                        help='Local dir to mount in the '
                        'image. Will be mounted at /external/<dirname>')
     group.add_argument('-a', '--enablerepo',
@@ -157,7 +164,7 @@ def buildparser():
     add_container_args(parser_container_build)
     group_container_build = parser_container_build.add_argument_group("build arguments")
     group_container_build.add_argument(
-        'source_dir', nargs='?', default='.',
+        'source_dir', nargs='?', type=dir_path, default='.',
         help="Root path where SPECS/ and SOURCES are available. "
              "The default is the working directory")
     group_container_build.add_argument(


### PR DESCRIPTION
When source_dir was provided with a non-directory (e.g. a specfile path), the script would fail when init-container tries to cd into it and report "/home/builder/rpmbuild: Not a directory".

This makes the error clearer by reporting about the host path.

Also, `--dir` was possible to check in the same way.

Opening this PR showed `CODEOWNERS` was missing, adding it at the same time.