### PR TITLE
container: add WORKDIR /build to Dockerfile-8.x

### DIFF
--- a/container/Dockerfile-8.x
+++ b/container/Dockerfile-8.x
@@ -63,5 +63,7 @@ COPY    files/init-container.sh /usr/local/bin/init-container.sh
 COPY    files/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY    --chown=builder:builder files/rpmmacros /home/builder/.rpmmacros
 
+WORKDIR /build
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
A user on the XCP-ng forum got a deeply confusing error while building a custom ISO with this container: `CRITICAL:yum.cli:Config error: Error accessing file for config file:////tmpdir-VcYHGW/yum-171swX.conf`. Forum thread here if useful: https://xcp-ng.org/forum/topic/12078/build-xcp-ng-iso-issue-at-create-installimg

The fix is one line. The `why` took longer than I'd like to admit.

Without a WORKDIR, Docker defaults to `/`. The build scripts in create-install-image set TMPDIR using `mktemp -d "$PWD/tmpdir-XXXXXX"`. When PWD is `/`, you get `//tmpdir-XXXXXX`. Linux handles that fine. Yum converts the config path to a `file://` URI, so you end up with `file:////tmpdir-...`, which Python 2's urllib won't open. And `cat` on the same file works perfectly, which makes the connection to the actual cause nearly impossible to see.

`WORKDIR /build` before the ENTRYPOINT sorts it out. I went with `/build` but I genuinely don't know if there's a convention here I've missed. Change it if there is.