### PR TITLE
Fix some build errors and warnings with our xcp-ng-dev containers.

### DIFF
--- a/container/Dockerfile-8.x
+++ b/container/Dockerfile-8.x
@@ -53,6 +53,7 @@ RUN     sed -i "/gpgkey/a exclude=ocaml*" /etc/yum.repos.d/Cent* /etc/yum.repos.
 # create the builder user
 RUN     groupadd -g 1000 builder \
         && useradd -u 1000 -g 1000 builder \
+        && gpasswd -a builder tty \
         && echo "builder:builder" | chpasswd \
         && echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 

--- a/container/files/init-container.sh
+++ b/container/files/init-container.sh
@@ -82,7 +82,9 @@ if [ -n "$BUILD_LOCAL" ]; then
         else
             specs=$(ls SPECS/*.spec 2>/dev/null)
             # SOURCES/ and SPECS/ are still the default in Alma10
-            SPECFLAGS=()
+            SPECFLAGS=(
+		--define "_sourcedir $PWD/SOURCES/"
+	    )
         fi
         echo "Found specfiles $specs"
 

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -239,6 +239,11 @@ def container(args):
     if args.debug:
         docker_args += ["-e", "SCRIPT_DEBUG=1"]
 
+    # Some build systems try to re-open /dev/stderr (->
+    # /dev/pts/0), so make sure pseudo-tty can be attached to
+    # in the build environment.
+    docker_args += ["--tty"]
+
     # --no-exit requires a tty
     wants_interactive = args.no_exit
 
@@ -274,7 +279,7 @@ def container(args):
             wants_interactive = True
 
     if wants_interactive:
-        docker_args += ["--interactive", "--tty"]
+        docker_args += ["--interactive"]
 
     # exec "docker run"
     docker_args += [f"{CONTAINER_PREFIX}:{args.container_version}",


### PR DESCRIPTION
A couple of commits here, one to remove a bunch of useless warnings when building locally, and another one actually fixing a build error in the intel-i40e-alt package, more information about the issue can be found directly in the commit description or on the intel-i40e-alt PR:

- https://github.com/xcp-ng-rpms/intel-i40e-alt/pull/6