### PR TITLE
Set the timezone in the container so it corresponds to the local machine

### DIFF
--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -38,7 +38,22 @@ def is_podman(runner):
 
 
 def get_timezone() -> str:
-    return subprocess.getoutput("timedatectl show -p Timezone --value")
+    # Forward the the `TZ` environment variable if provided
+    tz = os.environ.get("TZ")
+    if tz is not None:
+        return tz
+    # Otherwise use `timedatectl` if available, returning the timezone name
+    # (e.g `Europe/Paris`)
+    code, output = subprocess.getstatusoutput("timedatectl show -p Timezone --value")
+    if code == 0:
+        return output
+    # Then fallback to the last line of `/etc/localtime`, returning the timezone configuration
+    # (e.g `CET-1CEST,M3.5.0,M10.5.0/3`)
+    code, output = subprocess.getstatusoutput("tail -n 1 /etc/localtime")
+    if code == 0:
+        return output
+    # Then fallback to `UTC`
+    return "UTC"
 
 
 def get_local_image_platform(runner, image):

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -36,6 +36,11 @@ def is_podman(runner):
         return True
     return subprocess.getoutput(f"{runner} --version").startswith("podman ")
 
+
+def get_timezone() -> str:
+    return subprocess.getoutput("timedatectl show -p Timezone --value")
+
+
 def get_local_image_platform(runner, image):
     """Return the platform string (e.g. 'linux/amd64') of a local image, or None."""
     try:
@@ -280,6 +285,9 @@ def container(args):
 
     if wants_interactive:
         docker_args += ["--interactive"]
+
+    # Set the timezone of the container so it corresponds to the local machine
+    docker_args += ["-e", f"TZ={get_timezone()}"]
 
     # exec "docker run"
     docker_args += [f"{CONTAINER_PREFIX}:{args.container_version}",


### PR DESCRIPTION
This is done using the `TZ` environment variable


You can check that it works using:
```shell
± xcp-ng-dev container run 8.3 date
Launching docker with args ['docker', 'run', '-e', 'BUILDER_UID=1000', '-e', 'BUILDER_GID=1000', '--rm=true', '--ulimit', 'nofile=2048', '--platform', 'linux/amd64', '--pull', 'never', '--tty', '-e', 'COMMAND=date', '-e', 'TZ=Europe/Paris', 'ghcr.io/xcp-ng/xcp-ng-build-env:8.3', '/usr/local/bin/init-container.sh']
[...]
Wed Apr 29 17:05:37 CEST 2026
```

Note: a possible alternative would be to mount `/etc/localtime` and `/etc/timezone` using those docker options:
```
-v /etc/localtime:/etc/localtime:ro -v /etc/timezone:/etc/timezone:ro
```