### PR TITLE
Fail early when user repos cannot be downloaded

### DIFF
--- a/container/files/init-container.sh
+++ b/container/files/init-container.sh
@@ -27,8 +27,11 @@ case "$OS_RELEASE" in
 esac
 
 if [ -n "$XCPREL" ]; then
-    curl -s https://koji.xcp-ng.org/repos/user/${XCPREL}/xcpng-users.repo |
-        sed '/^gpgkey=/ ipriority=1' | sudo tee /etc/yum.repos.d/xcp-ng-users.repo > /dev/null
+    TMPFILE=$(mktemp)
+    curl --silent --fail https://koji.xcp-ng.org/repos/user/${XCPREL}/xcpng-users.repo -o "$TMPFILE"
+    sed -i -e '/^gpgkey=/ ipriority=1' "$TMPFILE"
+    sudo cp "$TMPFILE" /etc/yum.repos.d/xcp-ng-users.repo
+    rm "$TMPFILE"
 fi
 
 # yum or dnf?


### PR DESCRIPTION
In case of a failure of the koji server, curl does not fail on error, and inside a pipeline would not even cause immediate failure, instead dumping HTML error text into the repo file, triggering failure later.

This change fails early, while still minimizing the amount of code run as root.