### PR TITLE
Fix command encoding by using shlex/eval

### DIFF
--- a/container/files/init-container.sh
+++ b/container/files/init-container.sh
@@ -116,7 +116,7 @@ if [ -n "$BUILD_LOCAL" ]; then
         fi
     )
 elif [ -n "$COMMAND" ]; then
-    $COMMAND
+    eval "$COMMAND"
 else
     /bin/bash --login || true
 fi

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -10,6 +10,7 @@ Simplifies the creation of a build environment for XCP-ng packages.
 
 import argparse
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -293,7 +294,7 @@ def container(args):
             print(f"Building directory {build_dir}", file=sys.stderr)
 
         case 'run':
-            docker_args += ["-e", "COMMAND=%s" % ' '.join(args.command)]
+            docker_args += ["-e", f"COMMAND={shlex.join(args.command)}"]
 
         case 'shell':
             wants_interactive = True


### PR DESCRIPTION
At the moment the command provided to the container is not properly encoded, which causes commands that use quotes to fail unexpectedly:
```shell
± xcp-ng-dev container run 8.3 -- ls "my file.txt"
[...]
ls: cannot access my: No such file or directory
ls: cannot access file.txt: No such file or directory
```
This PR fixes this:
```shell
± xcp-ng-dev container run 8.3 -- ls "my file.txt"
[...]
ls: cannot access my file.txt: No such file or directory
```
Crucially, this allows for running shell commands:
```shell
± xcp-ng-dev container run 8.3 -- bash -c "echo 1 && echo 2"
[...]
1
2
```