### PR TITLE
xcp_ng_dev: add support for mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Note: unfortunately `rpmbuild` (in 8.3 at least) does not add all
 patches in `patches/series` upfront, so in case of real conflict this
 has to be redone from step 2 each time.
 
-## Building packages manually
+### Building packages manually
 
 If you need to build packages manually, here are some useful commands
 
@@ -173,7 +173,7 @@ cd xen-api
 make
 ```
 
-## Mounting external directories into the container
+### Mounting external directories into the container
 
 If you'd like to develop using the tools on your host and preserve the changes
 to source and revision control but still use the container for building, you

--- a/README.md
+++ b/README.md
@@ -185,3 +185,41 @@ then I can mount it inside the container as follows:
 ```sh
 xcp-ng-dev container shell -v /work/code:/mnt/repos 8.2
 ```
+
+### Using mock
+
+Mock is the tool used by koji to build packages.
+It uses chroots as the isolation mechanism instead of containers.
+The chrooted environments are called build roots.
+Mock uses koji tags instead of image tags to know how to create a build roots. 
+
+To build packages using mock, run `xcp-ng-dev mock`.
+This command accepts a variety of parameters allowing for different uses:
+* build a package from a directory that follows the rpmbuild convention (a
+  `SOURCES/` directory and a `SPECS/` directory).This is most useful for
+  building packages from XCP-ng's git repositories of RPM sources:
+  https://github.com/xcp-ng-rpms.
+* start a shell in the build environment, with the appropriate CentOS, EPEL and
+  XCP-ng yum repositories enabled.
+
+**Examples**
+
+Build from git (and put the result into RPMS/)
+```sh
+# Find the relevant repository at https://github.com/xcp-ng-rpms/
+# Make sure you have git-lfs installed before cloning.
+# Then... (Example taken: xapi)
+git clone https://github.com/xcp-ng-rpms/xapi.git
+
+# ... Here add your patches ...
+
+# Build.
+xcp-ng-dev mock build v8.3-incoming xapi/
+```
+
+**Important switches**
+
+* `shell` drops you to a shell, ready to run commands in the build environment with the sources loaded.
+* `list` lists the build roots present in the computer, these can be deleted with a simple rm -r
+* `--recreate` deletes the build root before running the command. Helpful to run when the build root has become outdated and building the package fails unexpectedly.
+

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -14,6 +14,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+from itertools import chain
 from pathlib import Path
 
 import argcomplete
@@ -436,11 +437,16 @@ def mock(args):
             else:
                 spec_file = Path(args.spec)
 
-            match (spec_file, list(specs_in(spec_dir))):
-                case (None, []):
-                    raise ValueError(f"No spec files found in {spec_dir}, please define one with --spec")
-                case None, [spec, *_] | (spec, _):
+            spec_candidates = list(chain(specs_in(source_dir), specs_in(spec_dir)))
+            match (spec_file, spec_candidates):
+                case None, [spec] | (spec, _):
                     mock_args += ["--spec", os.fspath(spec)]
+                case (None, []):
+                    raise ValueError(f"No spec files found in {source_dir} or {spec_dir}, please \
+                            define one with --spec")
+                case None, specs:
+                    raise ValueError(f"More than a spec file was found on {source_dir} and {spec_dir}: \
+                            {specs}, please define one with --spec")
 
         case 'shell':
             if args.spec is not None:

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -22,15 +22,20 @@ CONTAINER_PREFIX = "ghcr.io/xcp-ng/xcp-ng-build-env"
 DEFAULT_ULIMIT_NOFILE = 2048
 RPMBUILD_STAGES = "abpfcilsrd"  # valid X values in `rpmbuild -bX`
 
-RUNNER = os.getenv("XCPNG_OCI_RUNNER")
-if RUNNER is None:
-    SUPPORTED_RUNNERS = "docker podman"
-    for command in SUPPORTED_RUNNERS.split():
-        if shutil.which(command):
-            RUNNER = command
-            break
-    else:
-        raise Exception(f"cannot find a supported runner: {SUPPORTED_RUNNERS}")
+SUPPORTED_RUNNERS = ["docker", "podman"]
+
+RUNNERS_HELP = ' / '.join(SUPPORTED_RUNNERS)
+
+def get_runner():
+    RUNNER = os.getenv("XCPNG_OCI_RUNNER")
+    if RUNNER is None:
+        for command in SUPPORTED_RUNNERS:
+            if shutil.which(command):
+                RUNNER = command
+                break
+        else:
+            raise Exception(f"cannot find a supported runner: {SUPPORTED_RUNNERS}")
+    return RUNNER
 
 def is_podman(runner):
     if os.path.basename(runner) == "podman":
@@ -78,9 +83,6 @@ def add_common_args(parser):
     group.add_argument('-d', '--dir', action='append',
                        help='Local dir to mount in the '
                        'image. Will be mounted at /external/<dirname>')
-    group.add_argument('-e', '--env', action='append',
-                       help='Environment variables passed directly to '
-                       f'{RUNNER} -e')
     group.add_argument('-a', '--enablerepo',
                        help='additional repositories to enable before installing build dependencies. '
                        'Same syntax as yum\'s --enablerepo parameter. Available additional repositories: '
@@ -95,17 +97,20 @@ def add_common_args(parser):
 
 def add_container_args(parser):
     group = parser.add_argument_group("container arguments")
+    group.add_argument('-e', '--env', action='append',
+                       help='Environment variables passed directly to '
+                       f'{RUNNERS_HELP} -e')
     group.add_argument('container_version',
                        help='The version of XCP-ng container to for the build. For example, 8.3.')
     group.add_argument('-v', '--volume', action='append',
-                       help=f'Volume mounts passed directly to {RUNNER} -v')
+                       help=f'Volume mounts passed directly to {RUNNERS_HELP} -v')
     group.add_argument('--no-rm', action='store_true',
                        help='Do not destroy the container on exit')
     group.add_argument('--syslog', action='store_true',
                        help='Enable syslog to host by mounting in /dev/log')
     group.add_argument('--name', help='Assign a name to the container')
     group.add_argument('--ulimit', action='append',
-                       help=f'Ulimit options passed directly to {RUNNER} run')
+                       help=f'Ulimit options passed directly to {RUNNERS_HELP} run')
     group.add_argument('--platform', action='store',
                        help="Override the default platform for the build container. "
                        "Can notably be used to workaround podman bug #6185 fixed in v5.5.1.")
@@ -131,60 +136,61 @@ def buildparser():
         dest='action', required=True,
         help="Actions available for developing packages")
 
-    # build -- build an rpm using a container
-    parser_build = subparsers_container.add_parser(
+    # container build -- build an rpm using a container
+    parser_container_build = subparsers_container.add_parser(
         'build',
         help="Install dependencies for the spec file(s) found in the SPECS/ subdirectory "
              "of the directory passed as parameter, then build the RPM(s). "
              "Built RPMs and SRPMs will be in RPMS/ and SRPMS/ subdirectories. "
              "Any preexisting BUILD, BUILDROOT, RPMS or SRPMS directories will be removed first.")
-    add_common_args(parser_build)
-    add_container_args(parser_build)
-    group_build = parser_build.add_argument_group("build arguments")
-    group_build.add_argument(
+    add_common_args(parser_container_build)
+    add_container_args(parser_container_build)
+    group_container_build = parser_container_build.add_argument_group("build arguments")
+    group_container_build.add_argument(
         'source_dir', nargs='?', default='.',
         help="Root path where SPECS/ and SOURCES are available. "
              "The default is the working directory")
-    group_build.add_argument(
+    group_container_build.add_argument(
         '--define',
         help="Definitions to be passed to rpmbuild. Example: --define "
              "'xcp_ng_section extras', for building the 'extras' "
              "version of a package which exists in both 'base' and 'extras' versions.")
-    group_build.add_argument(
+    group_container_build.add_argument(
         '-o', '--output-dir',
         help="Directory where the RPMs, SRPMs and the build logs will appear. "
              "The directory is created if it doesn't exist")
-    group_build.add_argument(
+    group_container_build.add_argument(
         '--rpmbuild-opts', action='append',
         help="Pass additional option(s) to rpmbuild")
-    group_build.add_argument(
+    group_container_build.add_argument(
         '--rpmbuild-stage', action='store',
         help=f"Request given -bX stage rpmbuild, X in [{RPMBUILD_STAGES}]")
 
-    # run -- execute commands inside a container
-    parser_run = subparsers_container.add_parser(
+    # container run -- execute commands inside a container
+    parser_container_run = subparsers_container.add_parser(
         'run',
         help='Execute a command inside a container')
-    add_common_args(parser_run)
-    add_container_args(parser_run)
-    group_run = parser_run.add_argument_group("run arguments")
-    group_run.add_argument(
+    add_common_args(parser_container_run)
+    add_container_args(parser_container_run)
+    group_container_run = parser_container_run.add_argument_group("run arguments")
+    group_container_run.add_argument(
         'command', nargs='*',
         help='Command with arguments to run inside the container, '
              'if the command has arguments that start with --, '
              'separate the arguments for this tool and the command with " -- ".')
 
-    # shell -- like run bash
-    parser_shell = subparsers_container.add_parser(
+    # container shell -- like run bash
+    parser_container_shell = subparsers_container.add_parser(
         'shell',
         help='Drop a shell into the prepared container')
-    add_common_args(parser_shell)
-    add_container_args(parser_shell)
-    parser_run.add_argument_group("shell arguments")
+    add_common_args(parser_container_shell)
+    add_container_args(parser_container_shell)
+    parser_container_run.add_argument_group("shell arguments")
 
     return parser
 
 def container(args):
+    RUNNER = get_runner()
     docker_args = [RUNNER, "run"]
 
     if is_podman(RUNNER):

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -218,9 +218,19 @@ def buildparser():
         help="Root path where SPECS/ and SOURCES are available. "
              "The default is the working directory")
 
-    # TODO: mock run
+    parser_mock_shell = subparsers_mock.add_parser(
+        'shell',
+        help="Creates a build root for the koji tag if it doesn't exist yet, "
+             "drop the user into a shell within the build root with the "
+             "selected directory mounted.")
+    add_mock_args(parser_mock_shell)
+    group_mock_shell = parser_mock_shell.add_argument_group("shell arguments")
+    group_mock_shell.add_argument(
+        'source_dir', nargs='?', default='.',
+        help="Path that will be mounted in the build root. "
+             "The default is the working directory")
 
-    # TODO: mock shell
+    # TODO: mock run
 
     return parser
 
@@ -382,6 +392,14 @@ def ensure_mock_config(koji_tag):
 def specs_in(spec_dir):
     yield from (f for f in Path(spec_dir).glob('*.spec') if f.is_file())
 
+def mock_install_deps(build_root, spec_file):
+    mock_args = ["mock", "-r", build_root]
+    mock_args += ["--no-clean", "--no-cleanup-after"]
+    mock_args += ["--installdeps", spec_file]
+
+    print(f'Installing dependencies for "{spec_file}"')
+    return subprocess.call(mock_args)
+
 def mock(args):
     ensure_commands_available_for_mock_action()
     build_root = ensure_mock_config(args.koji_tag)
@@ -423,6 +441,23 @@ def mock(args):
                     raise ValueError(f"No spec files found in {spec_dir}, please define one with --spec")
                 case None, [spec, *_] | (spec, _):
                     mock_args += ["--spec", os.fspath(spec)]
+
+        case 'shell':
+            if args.spec is not None:
+                spec_file = Path(args.spec)
+                mock_install_deps(build_root, spec_file)
+
+            root_dir = "/tmp/buildroot"
+
+            mock_args += ["--shell"]
+            mock_args += common_args
+
+            mock_args += ["--cwd", root_dir]
+
+            mock_args += ["--enable-plugin", "bind_mount"]
+
+            mock_args += ["--unpriv",
+                          f'--plugin-option=bind_mount:dirs=[("{Path.absolute(source_dir)}", "{root_dir}")]']
 
     return subprocess.call(mock_args)
 

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -14,6 +14,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 import argcomplete
 
@@ -122,6 +123,14 @@ def add_container_args(parser):
     group.add_argument('--debug', action='store_true',
                        help='Enable script tracing in container initialization (sh -x)')
 
+def add_mock_args(parser):
+    group = parser.add_argument_group('mock arguments')
+    group.add_argument('koji_tag',
+                       help='The koji tag used for the build. For example, v8.3-incoming')
+    group.add_argument('--recreate', action='store_true',
+                       help='Destroy the existing build root before running the command.')
+    group.add_argument('--spec',
+                       help="SPEC file that defines the package to build.")
 
 def buildparser():
     parser = argparse.ArgumentParser()
@@ -186,6 +195,32 @@ def buildparser():
     add_common_args(parser_container_shell)
     add_container_args(parser_container_shell)
     parser_container_run.add_argument_group("shell arguments")
+
+    # mock-based workflow
+    parser_mock = subparsers_env.add_parser('mock', help="Use mock to build a package")
+    parser_mock.set_defaults(func=mock)
+    subparsers_mock = parser_mock.add_subparsers(
+        dest='action', required=True,
+        help="Actions available for developing packages")
+
+    # mock build
+    parser_mock_build = subparsers_mock.add_parser(
+        'build',
+        help="Creates a build root for the koji tag if it doesn't exist yet, "
+             "installs the needed dependencies in it needed for the packages, "
+             "then builds the RPM(s). Built RPMs and SRPMs will be in the "
+             "RPMS subdirectories.")
+    add_common_args(parser_mock_build)
+    add_mock_args(parser_mock_build)
+    group_mock_build = parser_mock_build.add_argument_group("build arguments")
+    group_mock_build.add_argument(
+        'source_dir', nargs='?', default='.',
+        help="Root path where SPECS/ and SOURCES are available. "
+             "The default is the working directory")
+
+    # TODO: mock run
+
+    # TODO: mock shell
 
     return parser
 
@@ -316,6 +351,76 @@ def container(args):
                     "/usr/local/bin/init-container.sh"]
     print("Launching docker with args %s" % docker_args, file=sys.stderr)
     return subprocess.call(docker_args)
+
+def ensure_commands_available_for_mock_action():
+    missing_commands = []
+    for command in ["mock", "koji"]:
+        if not shutil.which(command):
+            missing_commands += [command]
+
+    if missing_commands != []:
+        raise Exception(f"Cannot run mock because the commands {missing_commands} are not installed")
+
+def ensure_mock_config(koji_tag):
+    arch = "x86_64"
+    build_root = f"xcpng-{koji_tag}-latest-{arch}"
+    config_dir = Path.home() / ".config" / "mock"
+    config_file = config_dir / f"{build_root}.cfg"
+
+    if config_file.is_file():
+        print(f'Using existing mock configuration "{os.fspath(config_file)}"')
+        return build_root
+
+    os.makedirs(config_dir, exist_ok=True)
+    koji_args = ["koji", "mock-config", "--tag", koji_tag, "-a", arch, "-o", os.fspath(config_file)]
+    print(f"Creating mock configuration by running {koji_args}", file=sys.stderr)
+
+    subprocess.call(koji_args)
+
+    return build_root
+
+def specs_in(spec_dir):
+    yield from (f for f in Path(spec_dir).glob('*.spec') if f.is_file())
+
+def mock(args):
+    ensure_commands_available_for_mock_action()
+    build_root = ensure_mock_config(args.koji_tag)
+
+    mock_args = ["mock"]
+
+    common_args = ["-r", build_root, "--no-cleanup-after"]
+
+    if not args.recreate:
+        common_args += ["--no-clean"]
+
+    source_dir = Path(args.source_dir)
+
+    # action-specific
+    match args.action:
+        case 'build':
+            mock_args += ["--rebuild"]
+            mock_args += common_args
+
+            result_dir = source_dir / 'RPMS'
+            os.makedirs(result_dir, exist_ok=True)
+            mock_args += ["--resultdir", os.fspath(result_dir)]
+
+            sources_dir = source_dir / 'SOURCES'
+            mock_args += ["--sources", os.fspath(sources_dir)]
+
+            spec_dir = source_dir / 'SPECS/'
+            if args.spec is None:
+                spec_file = None
+            else:
+                spec_file = Path(args.spec)
+
+            match (spec_file, list(specs_in(spec_dir))):
+                case (None, []):
+                    raise ValueError(f"No spec files found in {spec_dir}, please define one with --spec")
+                case None, [spec, *_] | (spec, _):
+                    mock_args += ["--spec", os.fspath(spec)]
+
+    return subprocess.call(mock_args)
 
 def main():
     """ Main entry point. """

--- a/src/xcp_ng_dev/cli.py
+++ b/src/xcp_ng_dev/cli.py
@@ -386,6 +386,10 @@ def mock(args):
     ensure_commands_available_for_mock_action()
     build_root = ensure_mock_config(args.koji_tag)
 
+    print('\nNOTICE: The error of "package does not verify" can be fixed by '
+          'running `sudo sh -c \'echo "%_pkgverify_flags 0" >> '
+          '/etc/rpm/macros\'\n')
+
     mock_args = ["mock"]
 
     common_args = ["-r", build_root, "--no-cleanup-after"]


### PR DESCRIPTION
This allows users to use the build commit for mock. It creates the
configuration for mock using koji, and uses it to create the build root
and install dependencies.

This unblocks both building RPMs and using the shell for users, this means there
are quite a things missing, like:
- managing build roots (users probably want to delete them)
- allow users to pick a particular yum repository with a repoid, instead
  of using always latest
- allow users to pick arch64 repos, although I don't think it's useful
  now
- and others...