### PR TITLE
Use the packages from koji for XCP-ng 9

### DIFF
--- a/container/files/xcp-ng-8.99.repo
+++ b/container/files/xcp-ng-8.99.repo
@@ -1,8 +1,9 @@
 [xcpng]
 name=XCP-ng 8.99 test
-baseurl=https://repo.vates.tech/xcp-ng/9/8.99/base/@RPMARCH@/
+baseurl=https://kojihub.xcp-ng.org/kojifiles/repos/v9.0-incoming/latest/@RPMARCH@/
 enabled=1
 gpgcheck=0
 metadata_expire=0
 enabled_metadata=1
 priority=1
+sslverify=0


### PR DESCRIPTION
Fresh packages are currently built with Koji rather than with the BitBake
prototype, which required manual syncs. The original repository has
been inactive since February 2026.
